### PR TITLE
Add some extra features for Nuxt

### DIFF
--- a/src/data/frameworks/nuxt.ts
+++ b/src/data/frameworks/nuxt.ts
@@ -2,9 +2,9 @@ import { Vue } from "./vue";
 import { Framework, WebsiteType, AppType, FrameworkFeatures } from "../types";
 
 export const Nuxt: Framework = {
-  websiteTypesInOrderOfPriority: [WebsiteType.Hybrid, WebsiteType.Dynamic],
-  appTypesInOrderOfPriority: [AppType.Spa],
-  features: [FrameworkFeatures.TypeScript],
+  websiteTypesInOrderOfPriority: [WebsiteType.Hybrid, WebsiteType.Static, WebsiteType.Dynamic],
+  appTypesInOrderOfPriority: [AppType.Spa, AppType.Mpa],
+  features: [FrameworkFeatures.TypeScript, FrameworkFeatures.Cli],
   usesFrameworks: [Vue],
   templatingEngines: [],
   ecosystemIntegrations: [],


### PR DESCRIPTION
Static docs for Nuxt: https://nuxtjs.org/announcements/nuxt-static-improvements.

MPA support in Nuxt 2 is present in much the same way as for Next.js - you can always use `<a>` rather than `<NuxtLink>`. In addition, both Nuxt 2 + Nuxt 3 support zero-client-side JS rendering modes. (In Nuxt 3, it's turned on with [`experimental.noScripts`](https://github.com/nuxt/nuxt.js/issues/14765) ([docs](https://v3.nuxtjs.org/api/configuration/nuxt.config#noscripts)) and in Nuxt 2 it is turned on by setting `render.injectScripts` to false.)

And more features along those lines coming soon ....